### PR TITLE
Deployment improvements

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -1,15 +1,91 @@
 # Deploy production
 
+## Initial deployment
+
+Initial deployment is done once. [Update](#Update) section is executed for redeployment
+
+1. Create environment specific configuration file
+```bash
+# Run on local machine:
+ssh ubuntu@thenewboston.network 'sudo mkdir -p /etc/thenewboston' && \
+scp thenewboston/project/settings/templates/template.env ubuntu@thenewboston.network:/tmp/template.env && \
+ssh ubuntu@thenewboston.network 'sudo cp /tmp/template.env /etc/thenewboston/.env'
+
+# Update `/etc/thenewboston/.env` with actual values at thenewboston.network
+```
+
+2. Install docker as described at https://docs.docker.com/engine/install/ on thenewboston.network
+```bash
+# Known working versions described in the comments below 
+
+docker --version # Docker version 26.0.1, build d260a54
+
+# (!!!) At least Docker Compose version v2.24.0 is required
+docker compose version # Docker Compose version v2.26.1
+```
+
+3. Create database RDS instance:
+
+   3.1 Open AWS RDS -> Databases: https://us-west-2.console.aws.amazon.com/rds/home?region=us-west-2#databases
+
+   3.2 Click "Create database"
+
+   3.3 Fill in the following:
+
+   - Choose a database creation method: Standard create
+   - Engine options -> Engine type: PostgreSQL
+   - Engine options -> Engine version: 16.2
+   - Templates: Free tier
+   - Settings -> DB instance identifier: thenewboston
+   - Settings -> Credentials Settings -> Master username: thenewboston
+   - Settings -> Credentials Settings -> Credentials management: Self managed
+   - Settings -> Credentials Settings -> Master password: <replace with password>
+   - Settings -> Credentials Settings -> Confirm master password: <replace with password>
+   - Instance configuration -> DB instance class -> Burstable classes (includes t classes): db.t3.micro
+   - Storage -> Storage type -> gp2
+   - Storage -> Allocated storage: 20
+   - Storage -> Storage autoscaling -> Storage autoscaling -> Enable storage autoscaling: checked
+   - Storage -> Storage autoscaling -> Storage autoscaling -> Maximum storage threshold: 40
+   - Connectivity -> Compute resource: Don’t connect to an EC2 compute resource
+   - Connectivity -> Network type: IPv4
+   - Connectivity -> Virtual private cloud (VPC): Default VPC
+   - Connectivity -> DB subnet group: default
+   - Connectivity -> Public access: Yes
+   - Connectivity -> VPC security group (firewall) -> Create new: Automatic setup
+   - Connectivity -> New VPC security group name: thenewboston-database-sg
+   - Database authentication -> Database authentication options: Password authentication
+   - Monitoring -> Turn on Performance Insights: unchecked
+   - Monitoring -> Additional configuration -> Enable Enhanced Monitoring: unchecked
+   - Additional configuration -> Database options -> Initial database name: thenewboston
+   - Additional configuration -> Log exports -> PostgreSQL log: checked
+   - Additional configuration -> Log exports -> Upgrade log: checked
+   - Additional configuration -> Deletion protection -> Enable deletion protection: checked
+   - Additional configuration: leave defaults for the rest of the options
+
+```bash
+aws rds create-db-instance --db-instance-identifier thenewboston --db-instance-class db.t3.micro --engine postgres --engine-version 16.2 --allocated-storage 20 --master-username thenewboston --master-user-password '<replace with password>' --backup-retention-period 3 --db-subnet-group-name my-subnet-group --vpc-security-group-ids sg-xxxxxx --publicly-accessible
+aws rds create-db-instance --db-instance-identifier thenewboston --db-instance-class db.t2.micro --engine postgres --allocated-storage 20 --master-username thenewboston  --master-user-password '<replace with password>' --backup-retention-period 3 --db-subnet-group-name my-subnet-group --vpc-security-group-ids sg-xxxxxx --no-publicly-accessible
+aws ec2 authorize-security-group-ingress --group-id $SECURITY_GROUP_ID --protocol all --port all --cidr 0.0.0.0/0
+aws rds modify-db-instance --db-instance-identifier $TARGET_DB_IDENTIFIER --vpc-security-group-ids $SECURITY_GROUP_ID --apply-immediately
+aws rds wait db-instance-available --db-instance-identifier $TARGET_DB_IDENTIFIER
+aws rds modify-db-instance --db-instance-identifier $TARGET_DB_IDENTIFIER --master-user-password "$NEW_DB_PASSWORD" --apply-immediately
+```
+
 ## Update
 1. Login:
+
 ```bash
 ssh ubuntu@thenewboston.network
 ```
-2. Fetch the latest code:
+
+3. Fetch the latest code:
+
 ```bash
 cd thenewboston-Backend && git fetch origin
 ```
+
 3. Redeploy:
+
 ```bash
 docker-compose down  # skip if docker-compose.yml did not change since last deployment
 git checkout origin/master

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,8 +30,4 @@ RUN chmod a+x ./run-celery.sh
 COPY scripts/run-celery-beat.sh ./
 RUN chmod a+x ./run-celery-beat.sh
 
-RUN mkdir local
-# TODO(dmu) HIGH: Copying local files with credentials might be not the best idea. Consider changing it
-COPY local/settings.prod.py local/settings.prod.py
-
 COPY thenewboston thenewboston

--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,16 @@
-# TODO(dmu) MEDIUM: Upgrade docker everywhere and remove the following workaround
-DOCKER_COMPOSE_COMMAND := $(shell docker compose version >/dev/null 2>&1 && echo "docker compose" || echo "docker-compose")
-
-
 .PHONY: build
 build:
-	${DOCKER_COMPOSE_COMMAND} build --no-cache
+	# We are not building with Docker compose on purpose, so we can have just one image (and probably save disk space)
+	docker build . -t thenewboston-backend:current --no-cache
 
 .PHONY: run-production
-run-production:
-	${DOCKER_COMPOSE_COMMAND} up -d --force-recreate
+run-production:  # purposefully do not depend on `build` target
+	docker compose up -d --force-recreate
 
 .PHONY: run-development
-run-development:
+run-development: build
 	# docker-compose.yml is inherited and overridden by docker-compose.dev.yml
-	${DOCKER_COMPOSE_COMMAND} -f docker-compose.yml -f docker-compose.dev.yml up -d --force-recreate
+	docker compose -f docker-compose.yml -f docker-compose.dev.yml up --force-recreate
 
 .PHONY: deploy
 deploy: build run-production;
@@ -48,9 +45,8 @@ run-celery-beat:
 
 .PHONY: run-dependencies
 run-dependencies:
-	test -f .env || touch .env
 	# docker-compose.yml is inherited and overridden by docker-compose.dev.yml
-	${DOCKER_COMPOSE_COMMAND} -f docker-compose.yml -f docker-compose.dev.yml up --force-recreate db redis
+	docker compose -f docker-compose.yml -f docker-compose.dev.yml up --force-recreate db redis
 
 .PHONY: run-server
 run-server:

--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@
 
 # Initial Project Setup
 
-Clone the Repository
+1. Clone the Repository
 
 ```bash
 git clone https://github.com/thenewboston-developers/thenewboston-Backend.git
 ```
 
-Copy the settings templates into a new local directory:
+2. Copy the settings templates into a new local directory:
 
 ```bash
 mkdir -p local
@@ -21,15 +21,24 @@ cp thenewboston/project/settings/templates/settings.dev.py ./local/settings.dev.
 cp thenewboston/project/settings/templates/settings.unittests.py ./local/settings.unittests.py
 ```
 
-Commands for setting up local environment
-Make sure Docker is installed in your machine and run the following commands:
+3. Install / upgrade docker as described at https://docs.docker.com/engine/install/
+```bash
+# Known working versions described in the comments below 
+
+docker --version # Docker version 26.0.1, build d260a54
+
+# (!!!) At least Docker Compose version v2.24.0 is required
+docker compose version # Docker Compose version v2.26.1
+```
+
+4. Commands for setting up local environment. Run the following commands:
 
 ```bash
 make run-dependencies  # Sets up the necessary Docker containers for Redis and PostgreSQL
 make update            # Installs project dependencies, pre-commit and applies database migrations
 ```
 
-Fire Up the Server 🚀
+5. Fire Up the Server 🚀
 
 ```bash
 make run-server       # Starts the Django development server

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,21 +1,43 @@
-version: '3.9'
+x-service-override: &service-override
+    env_file:
+      - path: '.env'
+        required: false
+    environment:
+      THENEWBOSTON_SETTING_DATABASES: '{"default":{"HOST":"db"}}'
 
 services:
 
   db:
-    restart: 'no'  # so the service is not auto-started after developer's laptop reboot
+    image: postgres:16.2-alpine
+    restart: 'no'
+    ports:
+      - 127.0.0.1:5432:5432
+    environment:
+      POSTGRES_DB: thenewboston
+      POSTGRES_USER: thenewboston
+      POSTGRES_PASSWORD: thenewboston
+    healthcheck:
+      test: PGPASSWORD=$${POSTGRES_PASSWORD} pg_isready -d $${POSTGRES_DB} -U $${POSTGRES_USER}
+      interval: 10s
+      timeout: 5s
+      retries: 1
+    volumes:
+      - postgresql-data:/var/lib/postgresql/data
 
   redis:
     restart: 'no'  # so the service is not auto-started after developer's laptop reboot
 
   app:
     restart: 'no'  # so the service is not auto-started after developer's laptop reboot
+    <<: *service-override
 
   celery:
     restart: 'no'  # so the service is not auto-started after developer's laptop reboot
+    <<: *service-override
 
   celery-beat:
     restart: 'no'  # so the service is not auto-started after developer's laptop reboot
+    <<: *service-override
 
 volumes:
   postgresql-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,5 @@
-version: '3.9'
-
 x-service: &service
-    build: .
+    image: thenewboston-backend:current
     restart: unless-stopped
     depends_on:
       db:
@@ -9,32 +7,15 @@ x-service: &service
       redis:
         # TODO(dmu) LOW: Add redis health check and change to `condition: service_healthy`
         condition: service_started
+    env_file:
+      - path: '/etc/thenewboston/.env'
+        required: false
     environment:
-      THENEWBOSTON_SETTING_DATABASES: '{"default":{"HOST":"db"}}'
-      # TODO(dmu) MEDIUM: Use `env_file: /etc/thenewboston/.env` option instead of `local/settings.prod.py` file
-      THENEWBOSTON_SETTING_LOCAL_SETTINGS_PATH: local/settings.prod.py
       THENEWBOSTON_SETTING_CHANNEL_LAYERS: '{"default":{"CONFIG":{"hosts":[["redis", 6379]]}}}'
       THENEWBOSTON_SETTING_CELERY_RESULT_BACKEND: redis://redis:6379/0
       THENEWBOSTON_SETTING_CELERY_BROKER_URL: redis://redis:6379/0
 
 services:
-
-  db:
-    image: postgres:14.2-alpine
-    restart: unless-stopped
-    ports:
-      - 127.0.0.1:5432:5432
-    environment:
-      POSTGRES_DB: thenewboston
-      POSTGRES_USER: thenewboston
-      POSTGRES_PASSWORD: thenewboston
-    healthcheck:
-      test: PGPASSWORD=$${POSTGRES_PASSWORD} pg_isready -d $${POSTGRES_DB} -U $${POSTGRES_USER}
-      interval: 10s
-      timeout: 5s
-      retries: 1
-    volumes:
-      - postgresql-data:/var/lib/postgresql/data
 
   redis:
     image: redis:6.2.6-alpine
@@ -59,7 +40,5 @@ services:
     command: ./run-celery-beat.sh
 
 volumes:
-  postgresql-data:
-    driver: local
   redis-data:
     driver: local

--- a/thenewboston/project/settings/custom.py
+++ b/thenewboston/project/settings/custom.py
@@ -4,6 +4,8 @@ Settings specific to this application only (no Django or third party settings)
 
 IN_DOCKER = False
 
+# TODO(dmu) MEDIUM: Do we need both `ACCOUNT_NUMBER` and `SIGNING_KEY`.
+#                   Can't we derive `ACCOUNT_NUMBER` from `SIGNING_KEY`?
 ACCOUNT_NUMBER = None
 SIGNING_KEY = None
 

--- a/thenewboston/project/settings/templates/template.env
+++ b/thenewboston/project/settings/templates/template.env
@@ -1,0 +1,17 @@
+THENEWBOSTON_SETTING_SECRET_KEY='<replace with actual value>'
+
+THENEWBOSTON_SETTING_DATABASES='{"default":{"HOST":"<replace with actual value>","PASSWORD":"<replace with actual value>"}}'
+
+THENEWBOSTON_SETTING_SIGNING_KEY='<replace with actual value>'
+THENEWBOSTON_SETTING_ACCOUNT_NUMBER='<replace with actual value>'
+
+THENEWBOSTON_SETTING_OPENAI_API_KEY='<replace with actual value>'
+THENEWBOSTON_SETTING_PROMPTLAYER_API_KEY='<replace with actual value>'
+THENEWBOSTON_SETTING_GITHUB_API_ACCESS_TOKEN='<replace with actual value>'
+
+THENEWBOSTON_SETTING_AWS_ACCESS_KEY_ID='<replace with actual value>'
+THENEWBOSTON_SETTING_AWS_SECRET_ACCESS_KEY='<replace with actual value>'
+THENEWBOSTON_SETTING_AWS_STORAGE_BUCKET_NAME=thenewboston.network
+
+THENEWBOSTON_SETTING_CSRF_TRUSTED_ORIGINS='["https://thenewboston.network", "https://www.thenewboston.network"]'
+THENEWBOSTON_SETTING_ENV_NAME=production


### PR DESCRIPTION
Notes:
- Configuration for production is now read from /etc/thenewboston/.env . It is more secure and recommend way of providing dockerized app configuration: no need to include credentials in docker image and not need to rebuild image if settings change
- Image is built with `docker`, not with `docker compose`. This allows to have just one image, reuse it in several containers and potentially save disk space (space saving will be tested during deployment)

@buckyroberts @MAbdurrehman1 you will need to upgrade docker compose to at least version 2.24 (we need it to allow optional `.env` file for docker compose, previously some workaround were used instead) locally once this PR will be merged. I will take care about upgrading on production