### PR TITLE
152 - fix: openai failing test

### DIFF
--- a/thenewboston/art/tests/test_openai_image.py
+++ b/thenewboston/art/tests/test_openai_image.py
@@ -3,7 +3,7 @@ from django.test import override_settings
 from thenewboston.general.tests.vcr import assert_played, yield_cassette
 
 
-def test_create_openai_images(api_client_bucky):
+def test_create_openai_images(api_client_bucky, sample_core, sample_wallet):
     payload = {
         'description': 'A cat',
         'quantity': 1,

--- a/thenewboston/conftest.py
+++ b/thenewboston/conftest.py
@@ -3,3 +3,4 @@ from thenewboston.general.tests.fixtures import *  # noqa: F401, F403, E402
 from thenewboston.github.tests.fixtures import *  # noqa: F401, F403, E402
 from thenewboston.ia.tests.fixtures import *  # noqa: F401, F403, E402
 from thenewboston.users.tests.fixtures import *  # noqa: F401, F403, E402
+from thenewboston.wallets.tests.fixtures import *  # noqa: F401, F403, E402

--- a/thenewboston/wallets/tests/fixtures/__init__.py
+++ b/thenewboston/wallets/tests/fixtures/__init__.py
@@ -1,0 +1,1 @@
+from .wallet import *  # noqa: F401

--- a/thenewboston/wallets/tests/fixtures/wallet.py
+++ b/thenewboston/wallets/tests/fixtures/wallet.py
@@ -1,0 +1,12 @@
+import pytest
+from model_bakery import baker
+
+
+@pytest.fixture
+def sample_wallet(db, bucky, sample_core):
+    return baker.make(
+        'wallets.Wallet',
+        balance=750,
+        core=sample_core,
+        owner=bucky,
+    )

--- a/thenewboston/wallets/tests/fixtures/wallet.py
+++ b/thenewboston/wallets/tests/fixtures/wallet.py
@@ -6,7 +6,7 @@ from model_bakery import baker
 def sample_wallet(db, bucky, sample_core):
     return baker.make(
         'wallets.Wallet',
-        balance=750,
+        balance=1_000,
         core=sample_core,
         owner=bucky,
     )


### PR DESCRIPTION
Closes #152 

- Fixes `test_create_openai_images` by creating and passing `sample_core` and `sample_wallet` pytest fixtures, through which data is fed during the api test