### PR TITLE
201 - endpoint for getting user's default wallet

### DIFF
--- a/thenewboston/wallets/views/wallet.py
+++ b/thenewboston/wallets/views/wallet.py
@@ -14,6 +14,7 @@ from ..serializers.block import BlockSerializer
 from ..serializers.wallet import WalletReadSerializer, WalletWriteSerializer
 from ..serializers.wire import WireSerializer
 from ..serializers.withdraw import WithdrawSerializer
+from ..utils.wallet import get_default_wallet
 
 
 class WalletViewSet(
@@ -89,6 +90,17 @@ class WalletViewSet(
         wallet.save()
         read_serializer = WalletReadSerializer(wallet, context={'request': request})
 
+        return Response(read_serializer.data, status=status.HTTP_200_OK)
+
+    @action(detail=False, methods=['get'], url_path='default')
+    def default_wallet(self, request):
+        user = request.user
+        default_wallet = get_default_wallet(user)
+
+        if not default_wallet:
+            return Response({'error': 'Default wallet not found.'}, status=status.HTTP_404_NOT_FOUND)
+
+        read_serializer = WalletReadSerializer(default_wallet, context={'request': request})
         return Response(read_serializer.data, status=status.HTTP_200_OK)
 
     def get_queryset(self):


### PR DESCRIPTION
Closes #201 

### API Details

URL: 
```
base_domain/api/wallets/default
```
For Local (running on 8000)
```
http://localhost:8000/api/wallets/default
```

Example Response:
```
{
    "balance": 1090,
    "core": {
        "id": 1,
        "created_date": "2024-04-14T11:52:29.117397Z",
        "modified_date": "2024-04-14T11:53:36.289286Z",
        "domain": "thenewboston.com",
        "logo": "http://localhost:8000/media/images/tnb-logo_cHv935Y.png",
        "ticker": "TNB",
        "owner": 1
    },
    "created_date": "2024-04-29T07:59:48.605785Z",
    "deposit_account_number": "a7809323c895db95e25b82fec1d208ad4f7e17c14177d4481d857c2c14269874",
    "deposit_balance": 0,
    "id": 2,
    "modified_date": "2024-05-29T14:51:51.950459Z",
    "owner": 4
}
```

If wallet doesn't not exist, then example response:
```
{
    "error": "Default wallet not found."
}
```